### PR TITLE
Fix README Git LFS clone url

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Before cloning, install Git LFS:
 After installing Git LFS, clone the repository:
 
 ```sh
-git clone https://github.com/YOUR-USERNAME/YOUR-REPO.git
-cd YOUR-REPO
+git clone https://github.com/jayasanka-sack/openmrs-to-omop.git
+cd openmrs-to-omop
 ```
 
 Git LFS will automatically download the large files.


### PR DESCRIPTION
## Summary
- update Git LFS cloning instructions to use the repository's real URL

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fc6a9525c83318efc42c45135959e